### PR TITLE
Eliminated the gap between the github stat images

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1699,6 +1699,7 @@ input, select, textarea {
     }
 
     #mostusedlanguagespicture {
+        margin-top: -0.5rem;
         width: 55%;
     }
 

--- a/index.html
+++ b/index.html
@@ -73,13 +73,6 @@
                 was exactly what I was looking for.
             </p>
 
-
-
-            <p>
-                My goal is to apply this love for learning in the workplace to create optimal solutions
-                for the challenges at hand.
-            </p>
-
             <p class="section-separator"></p>
 
             <h3><u class="section-underline-major">My Work Experience</u></h3>
@@ -148,14 +141,17 @@
 
             <h3><u class="section-underline-major">My 2024 GitHub Activity</u></h3>
 
-            <img alt="GitHub activity image"
-                 id="githubactivitypicture"
-                 src="https://github-readme-stats.vercel.app/api?username=trbaxter&count_private=true\&theme=radical&show_icons=true"
-            />
-            <img alt="Most used languages image"
-                 id="mostusedlanguagespicture"
-                 src="https://github-readme-stats.vercel.app/api/top-langs/?username=trbaxter&size_weight=0.15&count_weight=0.5&layout=compact&theme=vision-friendly-dark"
-            />
+            <div id="github-picture-container">
+                <img alt="GitHub activity image"
+                     id="githubactivitypicture"
+                     src="https://github-readme-stats.vercel.app/api?username=trbaxter&count_private=true\&theme=radical&show_icons=true"
+                />
+                <img alt="Most used languages image"
+                     id="mostusedlanguagespicture"
+                     src="https://github-readme-stats.vercel.app/api/top-langs/?username=trbaxter&size_weight=0.15&count_weight=0.5&layout=compact&theme=vision-friendly-dark"
+                />
+            </div>
+
 
 
 


### PR DESCRIPTION
There was an annoying vertical gap between the two github stat pictures in the about page. Fixed.