### PR TITLE
fixed broken widget link

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,8 +97,7 @@
                 />
                 <img alt="Most used languages image"
                      id="mostusedlanguagespicture"
-                     src="https://github-readme-stats.vercel.app/api/top-langs/?username=trbaxter&size_weight=0.15\
-                          &count_weight=0.5&layout=compact&theme=vision-friendly-dark&hide=scss"
+                     src="https://github-readme-stats.vercel.app/api/top-langs/?username=trbaxter\&size_weight=0.15&count_weight=0.5&layout=compact&theme=vision-friendly-dark&hide=scss"
                 />
             </div>
         </article>


### PR DESCRIPTION
Splitting the link on my widget unfortunately broke the statistics that were listed. Fixed now.